### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+# Project Liberty Participation and Contribution Guidelines
+
+These technical guidelines apply to all [Project
+Liberty](https://ProjectLiberty.io/) development, although a given
+sub-project may extend or override some of these guidelines to suit
+its specific needs.
+
+Please see also the [Code of Conduct](CODE_OF_CONDUCT), which applies
+everywhere.
+
+## Standard Pull Request Model
+
+We use the typical GitHub [pull request
+(PR)](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests)
+development workflow.
+
+You're always welcome to open a PR in any repository here.  We
+encourage you to first post about your plans either in an issue ticket
+(an existing one or one you create) or in the [Discussion
+Forums](https://forum.projectliberty.io/).  That way you can get any
+important design feedback or suggestions before you start coding.
+
+It's also okay to post with questions before you've decided whether or
+not to contribute a change.
+
+## Writing Commit Messages
+
+When composing a commit message, please use [these
+guidelines](https://chris.beams.io/posts/git-commit/).  The quick
+summary is:
+
+* Limit the subject line to 50 characters 
+* Capitalize the first letter of the subject line, but...
+* ...Do not end the subject line with a period
+* Use the imperative mood in the subject line
+* Separate subject from body with a blank line
+* Wrap the body at 72 characters
+* Use the body to explain _what_ and _why_ more than _how_
+
+The reason for the short initial subject line is to support commands
+-- such as `git show-branch` -- that print summary lists of changes
+showing just the first line of each commit message, usually prefixed
+by some metadata on the left.  (And the reason for leaving the period
+off the subject line is thus to save space.)
+
+Think of the commit message is an introduction to the change.  A
+reviewer will read the commit message right before reading the diff
+itself, so the commit message's purpose is to put the reader in the
+right frame of mind to understand the code change.  The level of
+detail and specificity used in the message depends on the change.  If
+you're unsure, take a look at the repository's history, comparing
+commit messages with the corresponding diffs, and use that as a guide.
+
+**Mention related issues:** If the commit is related to one or more
+issue tickets, please mention each ticket number in the commit
+message, like this: "issue #123".
+
+## Indentation and Whitespace
+
+Please uses spaces not tabs for indentation, and avoid trailing
+whitespace.  If a language has a standard indentation amount, use that
+amount.  E.g., indent Javascript code by 2 spaces per level, Python
+code by 4 spaces, etc.
+
+## Keep Unrelated Changes Separate
+
+Please put logically distinct changes into separate commits.  For
+example, this commit message -- although correctly formatted -- should
+never happen:
+
+```
+  Fix issue #51 latency bug; also, fix formatting
+  
+  Stop syncing to permanent storage on every write.  That was causing
+  latency problems for clients who sent many files in a single request.
+  
+  Also, fix some longstanding formatting issues (trailing whitespace,
+  inconsistent indentation, etc) in the larger surrounding code block.
+```
+
+Even though one contiguous region of code was affected, there were
+really two logically unrelated changes made to it.  The better way
+would be to first commit the formatting fixes by themselves, with a
+commit message like this (a subject line is enough for a change like
+this -- the commit message does not need a body):
+
+```
+  Formatting fixes only; no substantive change
+```
+
+...and _then_ make the real change as a separate commit:
+
+```
+  Fix issue #51 latency bug
+  
+  Stop syncing to permanent storage on every write.  That was causing
+  latency problems for clients who sent many files in a single request.
+```
+
+Having the substantive change in its own commit means that now someone
+reviewing the change can see exactly the relevant diff, without being
+distracted by mere whitespace changes that don't affect the code's
+behavior.  This same reasoning applies even when the "other" change
+isn't a whitespace-only change: it's much easier for a reviewer to
+comprehend one change at a time than to try to comprehend multiple
+changes mixed together.
+
+## Change Documentation and Tests Together With Code
+
+Whenever possible, please include related documentation updates and
+test-suite updates directly in your change, i.e., in the same pull
+request as the core source code change.
+
+## Fixing Security Vulnerabilities
+
+If your change fixes a security vulnerability that is not already
+public knowledge, please check with [the security
+team](https://projectliberty.io/security-contact-or-some-such-url)
+before discussing the change in any public forums or posting a PR.
+
+### Expunging Branches Once They Are Merged
+
+In Project Liberty repositories, once a branch has been merged to
+mainline we usually delete the branch.  This can be done via the
+GitHub PR web interface (it offers a button to delete a PR's branch
+after merging), or from the command line:
+
+    # Make sure you're not on the branch you want to delete.
+    $ git branch | grep '^\* '
+    * main
+
+    # No output from this == up-to-date, nothing to fetch.
+    $ git fetch --dry-run
+
+    # Delete the branch locally, if necessary.
+    $ git branch -d some-now-fully-merged-branch
+
+    # Delete it upstream.
+    $ git push origin --delete some-now-fully-merged-branch
+
+This only applies to branches in the repositories we manage, of
+course.  For your own repositories (including the ones that are cloned
+from ours), you decide your own deletion policy, of course.


### PR DESCRIPTION
A few notes about this `CONTRIBUTING.md` file:

* None of it is written in stone.

  I thought it'd be most useful to come out of the gate with an opinionated and substantial `CONTRIBUTING.md`, but it's still just a draft.  Whatever in here isn't compatible with actual Project Liberty development practices, please replace.

* `liberty-web` seems like a reasonable place to put this for now, but it could as easily have been `example-client` or `spec`.

  Some projects have a dedicated repository for holding common cross-repository materials.  It's usually called `common` or `shared` or `meta` or something like that.  It holds the base `CONTRIBUTING.md` file, the `CODE_OF_CONDUCT`, and whatever else is needed.  Then the other repositories just incorporate things by reference.

* There are already `CONTRIBUTING.md` files in [sdk-ts](https://github.com/LibertyDSNP/sdk-ts/blob/main/CONTRIBUTING.md) and in [example-client](https://github.com/LibertyDSNP/example-client/blob/main/CONTRIBUTING.md).

  The former has a lot of material that's all highly `sdk-ts`-specific, so it should probably just link to this new baseline `CONTRIBUTING.md` from the top and then continue on to its project-specific guidelines.  The latter is a stub and doesn't have any real content yet anyway.

* This `CONTRIBUTING.md` currently links to `CODE_OF_CONDUCT.md` in the same repository.  But there are also Codes of Conduct in [spec](https://github.com/LibertyDSNP/spec/blob/main/CODEOFCONDUCT.md) and in [papers](https://github.com/LibertyDSNP/papers/blob/main/CODE_OF_CONDUCT.md).

  What I'd recommend is having the canonical Code of Conduct live as a web page (e.g., https://ProjectLiberty.io/code-of-conduct/) that is generated from `liberty-web`; this `CONTRIBUTING.md` would be updated to point to that web page.
